### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ The driversigs codebase comes from https://gist.github.com/jthuraisamy/4c4c751df
 Thank you to all of the contributors listed under contributors.  Each have contributed something meaningful to this repository and dealt with me and my review processes.  I appreciate each and every one of them for teaching me and helping to make this BOF repository the best it can be!
 
 ##### compiler used
-Precompiled BOF's are provided in this project and are compiled using a recent version of Mingw-w64 typcially installed from brew.
+Precompiled BOF's are provided in this project and are compiled using a recent version of Mingw-w64 typically installed from brew.
 
 

--- a/src/SA/adcs_enum/certca.h
+++ b/src/SA/adcs_enum/certca.h
@@ -1691,7 +1691,7 @@ CAGetCertTypeExtensions(
 //                          CT_EXTENSION_ISSUANCE_POLICY  (Version 2 template only)
 //                          CT_EXTENSION_OCSP_REV_NO_CHECK (Version 2 template only)
 //
-//                        0 means all avaiable extension for this CertType.
+//                        0 means all available extension for this CertType.
 //
 // pParam               - optional LDAP Handle
 // ppCertExtensions     - Pointer to a PCERT_EXTENSIONS to receive the result

--- a/src/SA/adcs_enum_com/certca.h
+++ b/src/SA/adcs_enum_com/certca.h
@@ -1691,7 +1691,7 @@ CAGetCertTypeExtensions(
 //                          CT_EXTENSION_ISSUANCE_POLICY  (Version 2 template only)
 //                          CT_EXTENSION_OCSP_REV_NO_CHECK (Version 2 template only)
 //
-//                        0 means all avaiable extension for this CertType.
+//                        0 means all available extension for this CertType.
 //
 // pParam               - optional LDAP Handle
 // ppCertExtensions     - Pointer to a PCERT_EXTENSIONS to receive the result

--- a/src/SA/driversigs/entry.c
+++ b/src/SA/driversigs/entry.c
@@ -40,7 +40,7 @@ DWORD validate_driver(wchar_t * file_path)
 {
 	DWORD dwStatus = ERROR_SUCCESS;
 	wchar_t mypath[512] = {0};
-	wchar_t *  drivers[8]; // make sure you update this if you cange the list below
+	wchar_t *  drivers[8]; // make sure you update this if you change the list below
 	PCCERT_CONTEXT certificate_context = NULL;
 	LPWIN_CERTIFICATE certificate = NULL;
 	LPWIN_CERTIFICATE certificate_header = NULL;

--- a/src/SA/findLoadedModule/entry.c
+++ b/src/SA/findLoadedModule/entry.c
@@ -15,7 +15,7 @@ BOOL ListModules(DWORD PID, const char * modSearchString)
 	{
 		if(SHLWAPI$StrStrIA(modinfo.szExePath, modSearchString))
 		{
-			//May be benificial to print off all hits even within a single process
+			//May be beneficial to print off all hits even within a single process
 			internal_printf("%s\n", modinfo.szExePath);
 			retVal = TRUE;
 			//break;

--- a/src/SA/netuser/entry.c
+++ b/src/SA/netuser/entry.c
@@ -11,7 +11,7 @@
 #define TICKSTO1970         0x019db1ded53e8000LL
 #define TICKSTO1980         0x01a8e79fe1d58000LL
 #define TICKSPERSEC        10000000
-#ifdef _WIN64 //can't use builtin function for extended divition on x86
+#ifdef _WIN64 //can't use builtin function for extended division on x86
 DWORD GetTimeInSeconds(VOID)
 {
     LARGE_INTEGER Time;

--- a/src/SA/reg_query/entry.c
+++ b/src/SA/reg_query/entry.c
@@ -26,7 +26,7 @@ void free_enums(){
     intFree(ERegTypes);
 }
 
-//HKEY compare didn't work in BOF for some reson
+//HKEY compare didn't work in BOF for some reason
 void set_hive_name(DWORD h)
 {
     if(h == 2)

--- a/src/common/bofdefs.h
+++ b/src/common/bofdefs.h
@@ -253,7 +253,7 @@ WINBASEAPI WINBOOL IMAGEAPI IMAGEHLP$ImageEnumerateCertificates(HANDLE FileHandl
 WINBASEAPI WINBOOL IMAGEAPI IMAGEHLP$ImageGetCertificateHeader(HANDLE FileHandle,DWORD CertificateIndex,LPWIN_CERTIFICATE Certificateheader);
 WINBASEAPI WINBOOL IMAGEAPI IMAGEHLP$ImageGetCertificateData(HANDLE FileHandle,DWORD CertificateIndex,LPWIN_CERTIFICATE Certificate,PDWORD RequiredLength);
 
-//cyprt32
+//crypt32
 WINIMPM WINBOOL WINAPI CRYPT32$CryptVerifyMessageSignature (PCRYPT_VERIFY_MESSAGE_PARA pVerifyPara, DWORD dwSignerIndex, const BYTE *pbSignedBlob, DWORD cbSignedBlob, BYTE *pbDecoded, DWORD *pcbDecoded, PCCERT_CONTEXT *ppSignerCert);
 WINIMPM DWORD WINAPI CRYPT32$CertGetNameStringW (PCCERT_CONTEXT pCertContext, DWORD dwType, DWORD dwFlags, void *pvTypePara, LPWSTR pszNameString, DWORD cchNameString);
 WINIMPM PCCERT_CONTEXT WINAPI CRYPT32$CertCreateCertificateContext (DWORD dwCertEncodingType, const BYTE *pbCertEncoded, DWORD cbCertEncoded);


### PR DESCRIPTION
There are small typos in:
- README.md
- src/SA/adcs_enum/certca.h
- src/SA/adcs_enum_com/certca.h
- src/SA/driversigs/entry.c
- src/SA/findLoadedModule/entry.c
- src/SA/netuser/entry.c
- src/SA/reg_query/entry.c
- src/common/bofdefs.h

Fixes:
- Should read `available` rather than `avaiable`.
- Should read `typically` rather than `typcially`.
- Should read `reason` rather than `reson`.
- Should read `division` rather than `divition`.
- Should read `crypt` rather than `cyprt`.
- Should read `change` rather than `cange`.
- Should read `beneficial` rather than `benificial`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md