### PR TITLE
Fix for VariantClear called on unint VARIANT

### DIFF
--- a/src/SA/adcs_enum_com/adcs_enum_com.c
+++ b/src/SA/adcs_enum_com/adcs_enum_com.c
@@ -293,11 +293,11 @@ HRESULT _adcs_get_CertRequest(BSTR bstrConfig)
 	CLSID	CLSID_CCertRequest = { 0x98AFF3F0, 0x5524, 0x11D0, {0x88, 0x12, 0x00, 0xA0, 0xC9, 0x03, 0xB8, 0x3C} };
 	IID		IID_ICertRequest2 = { 0xA4772988, 0x4A85, 0x4FA9, {0x82, 0x4E, 0xB5, 0xCF, 0x5C, 0x16, 0x40, 0x5A} };
 
+	OLEAUT32$VariantInit(&varProperty);
+
 	SAFE_RELEASE(pCertRequest);
 	hr = OLE32$CoCreateInstance(&CLSID_CCertRequest, 0, CLSCTX_INPROC_SERVER, &IID_ICertRequest2, (LPVOID *)&(pCertRequest));
 	CHECK_RETURN_FAIL("CoCreateInstance(CLSID_CCertRequest)", hr);
-
-	OLEAUT32$VariantInit(&varProperty);
 
 	hr = pCertRequest->lpVtbl->GetCAProperty(pCertRequest, bstrConfig, CR_PROP_CANAME, 0, PROPTYPE_STRING, 0, &varProperty);
 	CHECK_RETURN_FAIL("pCertRequest->lpVtbl->GetCAProperty(CR_PROP_CANAME)", hr);
@@ -703,7 +703,8 @@ HRESULT _adcs_get_TemplateExtendedKeyUsages(VARIANT* lpvarExtendedKeyUsages)
 
 	IID IID_IEnumVARIANT = { 0x00020404, 0x0000, 0x0000, {0xc0,0x00, 0x00,0x00,0x00,0x00,0x00,0x46} };
 	IID IID_IObjectId = { 0x728ab300, 0x217d, 0x11da, {0XB2, 0XA4, 0x00, 0x0E, 0x7B, 0xBB, 0x2B, 0x09} };
-	
+
+	OLEAUT32$VariantClear(&var);
 	if (NULL == lpvarExtendedKeyUsages->pdispVal)
 	{
 		internal_printf("      N/A\n");

--- a/src/SA/adcs_enum_com/adcs_enum_com.c
+++ b/src/SA/adcs_enum_com/adcs_enum_com.c
@@ -704,7 +704,7 @@ HRESULT _adcs_get_TemplateExtendedKeyUsages(VARIANT* lpvarExtendedKeyUsages)
 	IID IID_IEnumVARIANT = { 0x00020404, 0x0000, 0x0000, {0xc0,0x00, 0x00,0x00,0x00,0x00,0x00,0x46} };
 	IID IID_IObjectId = { 0x728ab300, 0x217d, 0x11da, {0XB2, 0XA4, 0x00, 0x0E, 0x7B, 0xBB, 0x2B, 0x09} };
 
-	OLEAUT32$VariantClear(&var);
+	OLEAUT32$VariantInit(&var);
 	if (NULL == lpvarExtendedKeyUsages->pdispVal)
 	{
 		internal_printf("      N/A\n");


### PR DESCRIPTION

There are a couple cases where VariantClear is called on unitialized VARIANTs. This could be a reliability or security issue.

See:

http://conference.hitb.org/hitbsecconf2009kl/materials/D1T2%20-%20Mark%20Dowd%20-%20Attacking%20Interoperability.pdf
or
https://devblogs.microsoft.com/cppblog/new-safety-rules-in-c-code-analysis/


> This warning is triggered when an uninitialized VARIANT is passed into an API that clears a VARIANT such as VariantClear. These APIs expect the VARIANT is initialized before they can be cleared. 



```diff
HRESULT _adcs_get_CertRequest(BSTR bstrConfig)
{
	HRESULT	hr = S_OK;
	ICertRequest2 * pCertRequest = NULL;
!	VARIANT varProperty;   <<<< uninitialized
	BSTR bstrCertificate = NULL;

	CLSID	CLSID_CCertRequest = { 0x98AFF3F0, 0x5524, 0x11D0, {0x88, 0x12, 0x00, 0xA0, 0xC9, 0x03, 0xB8, 0x3C} };
	IID		IID_ICertRequest2 = { 0xA4772988, 0x4A85, 0x4FA9, {0x82, 0x4E, 0xB5, 0xCF, 0x5C, 0x16, 0x40, 0x5A} };

+	OLEAUT32$VariantInit(&varProperty);

	SAFE_RELEASE(pCertRequest);
	hr = OLE32$CoCreateInstance(&CLSID_CCertRequest, 0, CLSCTX_INPROC_SERVER, &IID_ICertRequest2, (LPVOID *)&(pCertRequest));
!	CHECK_RETURN_FAIL("CoCreateInstance(CLSID_CCertRequest)", hr);  /// jumps to fail with varProperty uninitialized

	...
...
fail:

	SAFE_FREE(bstrCertificate);
!	OLEAUT32$VariantClear(&varProperty);   <<< VariantClear called on uninitialized variant
	SAFE_RELEASE(pCertRequest);
	
	return hr;
} // end _adcs_get_CertRequest
```



Here is another case:

```diff
HRESULT _adcs_get_TemplateExtendedKeyUsages(VARIANT* lpvarExtendedKeyUsages)
{
	HRESULT hr = S_OK;
	IObjectIds * pObjectIds = NULL;
	IEnumVARIANT *pEnum = NULL;
	LPUNKNOWN pUnk = NULL;
	VARIANT var;
	IDispatch *pDisp = NULL;
	ULONG lFetch = 0;
	IObjectId * pObjectId = NULL;
	BSTR bstFriendlyName = NULL;

	IID IID_IEnumVARIANT = { 0x00020404, 0x0000, 0x0000, {0xc0,0x00, 0x00,0x00,0x00,0x00,0x00,0x46} };
	IID IID_IObjectId = { 0x728ab300, 0x217d, 0x11da, {0XB2, 0XA4, 0x00, 0x0E, 0x7B, 0xBB, 0x2B, 0x09} };

+	OLEAUT32$VariantInit(&var);   // be sure to initialize
	if (NULL == lpvarExtendedKeyUsages->pdispVal)
	{
		internal_printf("      N/A\n");
		goto fail;
	}

...

fail:

!	OLEAUT32$VariantClear(&var);     <<<< potential VariantClear on uninitialized variant.

	return hr;
} // end _adcs_get_TemplateExtendedKeyUsages
```




`_adcs_get_Template(BSTR bstrOID)` does this correctly.
