### PR TITLE
Add call to VariantClear to release any resources

### DIFF
--- a/src/common/wmi.c
+++ b/src/common/wmi.c
@@ -535,6 +535,7 @@ HRESULT Wmi_ParseAllResults(
 	        {
 		        hr = WBEM_E_OUT_OF_MEMORY;
 		        BeaconPrintf(CALLBACK_ERROR, "KERNEL32$HeapReAlloc failed: 0x%08lx", hr);
+		        OLEAUT32$VariantClear(&varProperty);
 		        goto fail;
 	        }
 	        // If this isn't the first column, prepend a comma


### PR DESCRIPTION
Add call to VariantClear to release any resources held by varProperty in the case where goto fail is executed. This goto otherwise skips the VariantClear in line 551