### PR TITLE
Added base64 encoding for nTSecurityDescriptor to resolve ACLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Realistically, this could be compressed into a helper script, but those steps we
 |findLoadedModule|findLoadedModule [modulepart] [opt:procnamepart]| Finds what processes \*modulepart\* is loaded into, optionally searching just \*procnamepart\*|
 |get_password_policy|get_password_policy [hostname]| Gets target server or domain's configured password policy and lockouts|
 |ipconfig|ipconfig| Simply gets ipv4 addresses, hostname and dns server|
-|ldapsearch|ldapsearch [query] [opt: attribute] [opt: results_limit] [opt: DC hostname or IP] [opt: Distingished Name]| Executes LDAP searches |
+|ldapsearch|ldapsearch [query] [opt: attribute] [opt: results_limit] [opt: DC hostname or IP] [opt: Distingished Name]| Executes LDAP searches (NOTE: specify *,ntsecuritydescriptor as attribute if you want all attributes + ACL of the obje
+cts)|
 |listdns|listdns| Pulls dns cache entries, attempts to query and resolve each|
 |listmods|listmods [opt: pid]| List a process modules (DLL). Target current process if pid is empty. Complement to driversigs to determine if our process was injected by edr/av.|
 |listpipes|listpipes| Lists named pipes|

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Realistically, this could be compressed into a helper script, but those steps we
 |findLoadedModule|findLoadedModule [modulepart] [opt:procnamepart]| Finds what processes \*modulepart\* is loaded into, optionally searching just \*procnamepart\*|
 |get_password_policy|get_password_policy [hostname]| Gets target server or domain's configured password policy and lockouts|
 |ipconfig|ipconfig| Simply gets ipv4 addresses, hostname and dns server|
-|ldapsearch|ldapsearch [query] [opt: attribute] [opt: results_limit] [opt: DC hostname or IP] [opt: Distingished Name]| Executes LDAP searches (NOTE: specify *,ntsecuritydescriptor as attribute if you want all attributes + ACL of the obje
-cts)|
+|ldapsearch|ldapsearch [query] [opt: attribute] [opt: results_limit] [opt: DC hostname or IP] [opt: Distingished Name]| Executes LDAP searches (NOTE: specify *,ntsecuritydescriptor as attribute if you want all attributes + base64 encoded ACL of the objects, this can then be resolved using BOFHound)|
 |listdns|listdns| Pulls dns cache entries, attempts to query and resolve each|
 |listmods|listmods [opt: pid]| List a process modules (DLL). Target current process if pid is empty. Complement to driversigs to determine if our process was injected by edr/av.|
 |listpipes|listpipes| Lists named pipes|

--- a/src/SA/ldapsearch/entry.c
+++ b/src/SA/ldapsearch/entry.c
@@ -192,7 +192,7 @@ void customAttributes(PCHAR pAttribute, PCHAR pValue)
         internal_printf("%s", G);
         //RPCRT4$RpcStringFreeA(&G);       
         frpcstringfree(&G);
-    } else if (MSVCRT$strcmp(pAttribute, "nTSecurityDescriptor") == 0) {
+    } else if (MSVCRT$strcmp(pAttribute, "nTSecurityDescriptor") == 0 || MSVCRT$strcmp(pAttribute, "msDS-AllowedToActOnBehalfOfOtherIdentity") == 0) {
 		char *encoded = NULL;
 		PBERVAL tmp = (PBERVAL)pValue;
 		ULONG len = tmp->bv_len;
@@ -351,7 +351,7 @@ void ldapSearch(char * ldap_filter, char * ldap_attributes,	ULONG results_count,
             {
                 isbinary = FALSE;
                 // Get the string values.
-				if(MSVCRT$strcmp(pAttribute, "objectSid") == 0 || MSVCRT$strcmp(pAttribute, "objectGUID") == 0 || MSVCRT$strcmp(pAttribute, "nTSecurityDescriptor") == 0)
+				if(MSVCRT$strcmp(pAttribute, "objectSid") == 0 || MSVCRT$strcmp(pAttribute, "objectGUID") == 0 || MSVCRT$strcmp(pAttribute, "nTSecurityDescriptor") == 0 || MSVCRT$strcmp(pAttribute, "msDS-AllowedToActOnBehalfOfOtherIdentity") == 0)
                 {
 					//internal_printf("\n%s\n", pAttribute);
                     ppValue = (char **)WLDAP32$ldap_get_values_lenA(pLdapConnection, pEntry, pAttribute); //not really a char **


### PR DESCRIPTION
Let me know if this works without any memory leaks, it worked fine for me with several tries. Currently also working on returning msds-allowedtoactonbehalfofotheridentity as base64, then resolving it in BOFHound.

Quick thanks to Nico Leidecker from NVISO for helping with my noob C skills.