### PR TITLE
enumLocalSessions BOF Name

### DIFF
--- a/src/SA/enumLocalSessions/Makefile
+++ b/src/SA/enumLocalSessions/Makefile
@@ -1,4 +1,4 @@
-BOFNAME := enumlocalsessions
+BOFNAME := enumLocalSessions
 COMINCLUDE := -I ../../common
 LIBINCLUDE := -l wtsapi32
 CC_x64 := x86_64-w64-mingw32-gcc


### PR DESCRIPTION
Small fix to correct the BOF name of enumLocalSessions. All the others match, so this one is causing issues.