### PR TITLE
Tighten domain DN match to just the domainComponent RDN

### DIFF
--- a/src/SA/ldapsearch/entry.c
+++ b/src/SA/ldapsearch/entry.c
@@ -322,7 +322,7 @@ void ldapSearch(char * ldap_filter, char * ldap_attributes,	ULONG results_count,
     _ldap_search_abondon_page searchDone = (_ldap_search_abondon_page)GetProcAddress(wldap, "ldap_search_abandon_page");
     if(searchDone == NULL) {internal_printf("Unable to load required function"); return;}
 
-	distinguishedName = (domain) ? domain : MSVCRT$strstr(szDN, "DC");
+	distinguishedName = (domain) ? domain : MSVCRT$strstr(szDN, "DC=");
 	if(distinguishedName != NULL && res) {
     	internal_printf("[*] Distinguished name: %s\n", distinguishedName);	
 	}


### PR DESCRIPTION
For a DN that ends in 'OU=DC,DC=example,DC=com' the strstr match in ldapSearch() will match the 'DC' value of the OU and will build a DN of 'DC,DC=example,DC=com' which is invalid. This naturally also applies to the letter sequence 'DC' anywhere in the DN.