### PR TITLE
Update wmi.c

### DIFF
--- a/SA/SA.cna
+++ b/SA/SA.cna
@@ -125,7 +125,7 @@ alias dir {
 		$text = "Issuing local dir to $targetdir";
 	}
 
-	$args = bof_pack($1, "Zs", $targetdir, $subdirs);
+	$args = bof_pack($1, "zs", $targetdir, $subdirs);
 	beacon_inline_execute($1, readbof($1, "dir", $msg, $ttp), "go", $args);
 }
 

--- a/src/SA/dir/entry.c
+++ b/src/SA/dir/entry.c
@@ -38,7 +38,7 @@ void listDir(char *path, unsigned short subdirs) {
 	// Query the first file
 	(hand = KERNEL32$FindFirstFileA(path, &fd));
 	if (hand == INVALID_HANDLE_VALUE) {
-		BeaconPrintf(CALLBACK_ERROR, "Couldn't open %d: Error %u", pathlen, KERNEL32$GetLastError());
+		BeaconPrintf(CALLBACK_ERROR, "Couldn't open %s: Error %u", path, KERNEL32$GetLastError());
 		KERNEL32$FindClose(hand);
 		return;
 	}

--- a/src/SA/dir/entry.c
+++ b/src/SA/dir/entry.c
@@ -3,52 +3,54 @@
 #include "base.c"
 #include "queue.c"
 
-void listDir(wchar_t *path, unsigned short subdirs) {
+void listDir(char *path, unsigned short subdirs) {
 
-	WIN32_FIND_DATAW fd = {0};
+	WIN32_FIND_DATA fd = {0};
 	HANDLE hand = NULL;
 	LARGE_INTEGER fileSize;
 	LONGLONG totalFileSize = 0;
 	int nFiles = 0;
 	int nDirs = 0;
 	Pqueue dirQueue = queueInit();
-	wchar_t * uncIndex;
+	char * uncIndex;
 	char * curitem;
-	WCHAR * nextPath;
-	int pathlen = MSVCRT$wcslen(path);
+	char * nextPath;
+	int pathlen = MSVCRT$strlen(path);
 
 	// Per MSDN: "On network shares ... you cannot use an lpFileName that points to the share itself; for example, "\\Server\Share" is not valid."
 	// Workaround: If we're using a UNC Path, there'd better be at least 4 backslashes
 	// This breaks the convention, but a `cmd /c dir \\hostname\admin$` will work, so let's replicate that functionality.
-	if (MSVCRT$_wcsnicmp(path, L"\\\\", 2) == 0) {
-		uncIndex = MSVCRT$wcsstr(path + 2, L"\\");
-		if (uncIndex != NULL && MSVCRT$wcsstr(uncIndex + 1, L"\\") == NULL) {
-			MSVCRT$wcscat(path, L"\\");
+	if (MSVCRT$_strnicmp(path, "\\\\", 2) == 0) {
+		uncIndex = MSVCRT$strstr(path + 2, "\\");
+		if (uncIndex != NULL && MSVCRT$strstr(uncIndex + 1, "\\") == NULL) {
+			MSVCRT$strcat(path, "\\");
 			pathlen = pathlen + 1;
 		}
 	}
 
 	// If the file ends in \ or is a drive (C:), throw a * on there
-	if (MSVCRT$_wcsicmp(path + pathlen - 1, L"\\") == 0) {
-		MSVCRT$wcscat(path, L"*");
-	} else if (MSVCRT$_wcsicmp(path + pathlen - 1, L":") == 0) {
-		MSVCRT$wcscat(path, L"\\*");
+	if (MSVCRT$strcmp(path + pathlen - 1, "\\") == 0) {
+		MSVCRT$strcat(path, "*");
+	} else if (MSVCRT$strcmp(path + pathlen - 1, ":") == 0) {
+		MSVCRT$strcat(path, "\\*");
 	}
 
 	// Query the first file
-	(hand = KERNEL32$FindFirstFileW(path, &fd));
+	(hand = KERNEL32$FindFirstFileA(path, &fd));
 	if (hand == INVALID_HANDLE_VALUE) {
-		BeaconPrintf(CALLBACK_ERROR, "Couldn't open %ls: Error %lu", path, KERNEL32$GetLastError());
+		BeaconPrintf(CALLBACK_ERROR, "Couldn't open %d: Error %u", pathlen, KERNEL32$GetLastError());
+		KERNEL32$FindClose(hand);
 		return;
 	}
 	// If it's a single directory without a wildcard, re-run it with a \*
-	if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY && MSVCRT$wcsstr(path, L"*") == NULL) {
-		MSVCRT$wcscat(path, L"\\*");
+	if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY && MSVCRT$strstr(path, "*") == NULL) {
+		MSVCRT$strcat(path, "\\*");
 		listDir(path, subdirs);
+		KERNEL32$FindClose(hand);
 		return;
 	}
 
-	internal_printf("Contents of %ls:\n", path);
+	internal_printf("Contents of %s:\n", path);
 	do {
 		// Get file write time
 		SYSTEMTIME stUTC, stLocal;
@@ -61,31 +63,31 @@ void listDir(wchar_t *path, unsigned short subdirs) {
 		// File size (or ujust print dir)
 		if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
 			if (fd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) {
-				internal_printf("%16s %ls\n", "<junction>", fd.cFileName);
+				internal_printf("%16s %s\n", "<junction>", fd.cFileName);
 			} else {
-				internal_printf("%16s %ls\n", "<dir>", fd.cFileName);
+				internal_printf("%16s %s\n", "<dir>", fd.cFileName);
 			}
 			nDirs++;
 			// ignore . and ..
-			if (MSVCRT$wcscmp(fd.cFileName, L".") == 0 || MSVCRT$wcscmp(fd.cFileName, L"..") == 0) {
+			if (MSVCRT$strcmp(fd.cFileName, ".") == 0 || MSVCRT$strcmp(fd.cFileName, "..") == 0) {
 				continue;
 			}
 			// Queue subdirectory for recursion
 			if (subdirs) {
-				nextPath = (WCHAR *)intAlloc((MSVCRT$wcslen(path) + MSVCRT$wcslen(fd.cFileName) + 3) * 2);
-				MSVCRT$wcsncat(nextPath, path, MSVCRT$wcslen(path)-1);
-				MSVCRT$wcscat(nextPath, fd.cFileName);
+				nextPath = intAlloc(MSVCRT$strlen(path) + MSVCRT$strlen(fd.cFileName) + 1);
+				MSVCRT$strncat(nextPath, path, MSVCRT$strlen(path)-1);
+				MSVCRT$strcat(nextPath, fd.cFileName);
 				dirQueue->push(dirQueue, nextPath);
 			}
 		} else {
 			fileSize.LowPart = fd.nFileSizeLow;
 			fileSize.HighPart = fd.nFileSizeHigh;
-			internal_printf("%16lld %ls\n", fileSize.QuadPart, fd.cFileName);
+			internal_printf("%16lld %s\n", fileSize.QuadPart, fd.cFileName);
 
 			nFiles++;
 			totalFileSize += fileSize.QuadPart;
 		}
-	} while(KERNEL32$FindNextFileW(hand, &fd));
+	} while(KERNEL32$FindNextFileA(hand, &fd));
 	internal_printf("\t%32lld Total File Size for %d File(s)\n", totalFileSize, nFiles);
 	internal_printf("\t%55d Dir(s)\n", nDirs);
 
@@ -99,7 +101,7 @@ void listDir(wchar_t *path, unsigned short subdirs) {
 
 	KERNEL32$FindClose(hand);
 	while((curitem = dirQueue->pop(dirQueue)) != NULL) {
-		listDir((wchar_t *)curitem, subdirs);
+		listDir(curitem, subdirs);
 		intFree(curitem);
 	}
 	dirQueue->free(dirQueue);
@@ -114,13 +116,13 @@ VOID go(
 {
 	datap parser = {0};
 	BeaconDataParse(&parser, Buffer, Length);
-	wchar_t * path = (wchar_t *)BeaconDataExtract(&parser, NULL);
+	char * path = BeaconDataExtract(&parser, NULL);
 	unsigned short subdirs = BeaconDataShort(&parser);
 
 	// Not positive how long path is, let's be safe
 	// At worst, we will append \* so give it four bytes (= 2 wchar_t)
-	wchar_t * realPath = intAlloc(1024);
-	MSVCRT$wcsncat(realPath, path, 1020);
+	char * realPath = intAlloc(1024);
+	MSVCRT$strncat(realPath, path, 1024);
 
 	if(!bofstart())
 	{

--- a/src/SA/dir/entry.c
+++ b/src/SA/dir/entry.c
@@ -74,7 +74,7 @@ void listDir(char *path, unsigned short subdirs) {
 			}
 			// Queue subdirectory for recursion
 			if (subdirs) {
-				nextPath = intAlloc(MSVCRT$strlen(path) + MSVCRT$strlen(fd.cFileName) + 1);
+				nextPath = intAlloc((MSVCRT$strlen(path) + MSVCRT$strlen(fd.cFileName) + 3)*2);
 				MSVCRT$strncat(nextPath, path, MSVCRT$strlen(path)-1);
 				MSVCRT$strcat(nextPath, fd.cFileName);
 				dirQueue->push(dirQueue, nextPath);
@@ -122,7 +122,7 @@ VOID go(
 	// Not positive how long path is, let's be safe
 	// At worst, we will append \* so give it four bytes (= 2 wchar_t)
 	char * realPath = intAlloc(1024);
-	MSVCRT$strncat(realPath, path, 1024);
+	MSVCRT$strncat(realPath, path, 1023);
 
 	if(!bofstart())
 	{

--- a/src/common/bofdefs.h
+++ b/src/common/bofdefs.h
@@ -62,7 +62,9 @@ WINBASEAPI DWORD WINAPI KERNEL32$GetFullPathNameW (LPCWSTR lpFileName, DWORD nBu
 WINBASEAPI DWORD WINAPI KERNEL32$GetFileAttributesW (LPCWSTR lpFileName);
 WINBASEAPI DWORD WINAPI KERNEL32$GetCurrentDirectoryW (DWORD nBufferLength, LPWSTR lpBuffer);
 WINBASEAPI HANDLE WINAPI KERNEL32$FindFirstFileW (LPCWSTR lpFileName, LPWIN32_FIND_DATAW lpFindFileData);
+WINBASEAPI HANDLE WINAPI KERNEL32$FindFirstFileA (char * lpFileName, LPWIN32_FIND_DATA lpFindFileData);
 WINBASEAPI WINBOOL WINAPI KERNEL32$FindNextFileW (HANDLE hFindFile, LPWIN32_FIND_DATAW lpFindFileData);
+WINBASEAPI WINBOOL WINAPI KERNEL32$FindNextFileA (HANDLE hFindFile, LPWIN32_FIND_DATA lpFindFileData);
 WINBASEAPI WINBOOL WINAPI KERNEL32$FindClose (HANDLE hFindFile);
 WINBASEAPI VOID WINAPI KERNEL32$SetLastError (DWORD dwErrCode);
 #define intAlloc(size) KERNEL32$HeapAlloc(KERNEL32$GetProcessHeap(), HEAP_ZERO_MEMORY, size)
@@ -122,11 +124,13 @@ WINBASEAPI wchar_t *__cdecl MSVCRT$wcstok_s(wchar_t *_Str,const wchar_t *_Delim,
 WINBASEAPI wchar_t *__cdecl MSVCRT$wcsstr(const wchar_t *_Str,const wchar_t *_SubStr);
 WINBASEAPI wchar_t *__cdecl MSVCRT$wcscat(wchar_t * __restrict__ _Dest,const wchar_t * __restrict__ _Source);
 WINBASEAPI wchar_t *__cdecl MSVCRT$wcsncat(wchar_t * __restrict__ _Dest, const wchar_t * __restrict__ _Source, size_t _Count);
+WINBASEAPI wchar_t *__cdecl MSVCRT$strncat(char * __restrict__ _Dest,const char * __restrict__ _Source, size_t _Count);
 WINBASEAPI wchar_t *__cdecl MSVCRT$wcscpy(wchar_t * __restrict__ _Dest, const wchar_t * __restrict__ _Source);
 WINBASEAPI int __cdecl MSVCRT$_wcsicmp(const wchar_t *_Str1,const wchar_t *_Str2);
 WINBASEAPI int __cdecl MSVCRT$_wcsnicmp(const wchar_t *_Str1,const wchar_t *_Str2, size_t _Count);
+WINBASEAPI int __cdecl MSVCRT$_strnicmp(const char *_Str1,const char *_Str2, size_t _Count);
 WINBASEAPI _CONST_RETURN wchar_t *__cdecl MSVCRT$wcschr(const wchar_t *_Str, wchar_t _Ch);
-WINBASEAPI wchar_t * __cdecl MSVCRT$wcsncat(wchar_t * __restrict__ _Dest,const wchar_t * __restrict__ _Source,size_t _Count);
+
 WINBASEAPI wchar_t *__cdecl MSVCRT$wcsrchr(const wchar_t *_Str,wchar_t _Ch);
 WINBASEAPI wchar_t *__cdecl MSVCRT$wcsrchr(const wchar_t *_Str,wchar_t _Ch);
 WINBASEAPI unsigned long __cdecl MSVCRT$wcstoul(const wchar_t * __restrict__ _Str,wchar_t ** __restrict__ _EndPtr,int _Radix);
@@ -142,8 +146,6 @@ DECLSPEC_IMPORT PCHAR __cdecl MSVCRT$strchr(const char *haystack, int needle);
 DECLSPEC_IMPORT char *__cdecl MSVCRT$strtok(char * __restrict__ _Str,const char * __restrict__ _Delim);
 _CRTIMP char *__cdecl MSVCRT$strtok_s(char *_Str,const char *_Delim,char **_Context);
 WINBASEAPI unsigned long __cdecl MSVCRT$strtoul(const char * __restrict__ _Str,char ** __restrict__ _EndPtr,int _Radix);
-WINBASEAPI size_t __cdecl MSVCRT$strftime(char *_DstBuf,size_t _SizeInBytes,const char *_Format,const struct tm *_Tm);
-WINBASEAPI struct tm * __cdecl MSVCRT$gmtime(const time_t *_Time);
 
 //DNSAPI
 DECLSPEC_IMPORT DNS_STATUS WINAPI DNSAPI$DnsQuery_A(PCSTR,WORD,DWORD,PIP4_ARRAY,PDNS_RECORD*,PVOID*);
@@ -172,7 +174,6 @@ WINBASEAPI DWORD WINAPI NETAPI32$NetApiBufferFree(LPVOID Buffer);
 WINBASEAPI DWORD WINAPI NETAPI32$NetSessionEnum(LPCWSTR servername, LPCWSTR UncClientName, LPCWSTR username, DWORD level, LPBYTE* bufptr, DWORD prefmaxlen, LPDWORD entriesread, LPDWORD totalentries, LPDWORD resumehandle);
 WINBASEAPI DWORD WINAPI NETAPI32$NetWkstaUserEnum(LMSTR servername,DWORD level,LPBYTE *bufptr,DWORD prefmaxlen,LPDWORD entriesread,LPDWORD totalentries,LPDWORD resumehandle);
 WINBASEAPI DWORD WINAPI NETAPI32$NetStatisticsGet(LMSTR server,LMSTR service,DWORD level,DWORD options,LPBYTE *bufptr);
-WINBASEAPI DWORD WINAPI NETAPI32$NetRemoteTOD(LPCWSTR UncServerName,LPBYTE  *BufferPtr);
 
 //mpr
 WINBASEAPI DWORD WINAPI MPR$WNetOpenEnumW(DWORD dwScope, DWORD dwType, DWORD dwUsage, LPNETRESOURCEW lpNetResource, LPHANDLE lphEnum);
@@ -490,6 +491,8 @@ DECLSPEC_IMPORT WINBOOL WINAPI VERSION$VerQueryValueA(LPCVOID pBlock, LPCSTR lpS
 #define KERNEL32$GetCurrentDirectoryW  GetCurrentDirectoryW 
 #define KERNEL32$FindFirstFileW  FindFirstFileW 
 #define KERNEL32$FindNextFileW  FindNextFileW 
+#define KERNEL32$FindFirstFileA  FindFirstFileA
+#define KERNEL32$FindNextFileA  FindNextFileA 
 #define KERNEL32$FindClose  FindClose 
 #define KERNEL32$SetLastError  SetLastError 
 #define KERNEL32$HeapAlloc HeapAlloc

--- a/src/common/wmi.c
+++ b/src/common/wmi.c
@@ -61,12 +61,13 @@ HRESULT Wmi_Initialize(WMI* pWmi)
 		NULL, 
 		COINIT_APARTMENTTHREADED
 	);
-	if (FAILED(hr))
-	{
-		BeaconPrintf(CALLBACK_ERROR, "OLE32$CoInitializeEx failed: 0x%08lx", hr);
-		goto fail;
+	if (hr == RPC_E_CHANGED_MODE) {
+    		hr = S_OK;
+	} else if (FAILED(hr)) {
+    		BeaconPrintf(CALLBACK_ERROR, "OLE32$CoInitializeEx failed: 0x%08lx", hr);
+    		goto fail;
 	}
-		hr = OLE32$CoInitializeSecurity( //Failure of this function does not necessarily mean we failed to initialize, it will fail on repeated calls, but the values from the original call are retained
+	hr = OLE32$CoInitializeSecurity( //Failure of this function does not necessarily mean we failed to initialize, it will fail on repeated calls, but the values from the original call are retained
 			NULL,
             -1,
             NULL,


### PR DESCRIPTION
COM might have already been initialized in the beacon and not closed. Since we are not dealing with UI operations, there's no need to consider the threading model. Therefore, we can use the already initialized COM. Hence, if an RPC_E_CHANGED_MODE error occurs, we can continue executing.