### PR TITLE
Patch to reg_query

### DIFF
--- a/src/SA/reg_query/Makefile
+++ b/src/SA/reg_query/Makefile
@@ -1,6 +1,6 @@
 BOFNAME := reg_query
 COMINCLUDE := -I ../../common
-LIBINCLUDE := 
+LIBINCLUDE := -lshlwapi
 CC_x64 := x86_64-w64-mingw32-gcc
 CC_x86 := i686-w64-mingw32-gcc
 CC=x86_64-w64-mingw32-clang

--- a/src/SA/reg_query/entry.c
+++ b/src/SA/reg_query/entry.c
@@ -195,7 +195,9 @@ DWORD Reg_GetValue(const char * hostname, HKEY hivekey, DWORD Arch, const char* 
     );
 	if(!dwRet)
 	{
-        internal_printf("%s\\%s\n", gHiveName, keystring);
+        char stringDate[19];
+        Reg_KeyToTimestamp(curitem->hreg, stringDate);
+        internal_printf("%24s %s\\%s\n", stringDate, gHiveName, keystring);
         Reg_InternalPrintKey(ValueData, value, type, size, key);
 	}
     END:

--- a/src/SA/reg_query/entry.c
+++ b/src/SA/reg_query/entry.c
@@ -196,7 +196,7 @@ DWORD Reg_GetValue(const char * hostname, HKEY hivekey, DWORD Arch, const char* 
 	if(!dwRet)
 	{
         char stringDate[19];
-        Reg_KeyToTimestamp(curitem->hreg, stringDate);
+        Reg_KeyToTimestamp(key, stringDate);
         internal_printf("%24s %s\\%s\n", stringDate, gHiveName, keystring);
         Reg_InternalPrintKey(ValueData, value, type, size, key);
 	}

--- a/src/SA/reg_query/entry.c
+++ b/src/SA/reg_query/entry.c
@@ -12,10 +12,6 @@ char ** ERegTypes = 1;
 char * gHiveName = 1;
 #pragma GCC diagnostic pop
 //const char * hostname, HKEY hivekey, DWORD Arch, const char* keystring, int depth, int maxdepth)
-DECLSPEC_IMPORT WINAPI LSTATUS ADVAPI32$RegQueryInfoKeyA(HKEY hKey, LPSTR lpClass, LPDWORD lpcchClass, LPDWORD lpReserved, LPDWORD lpcSubKeys, LPDWORD lpcbMaxSubKeyLen,
-                                LPDWORD lpcbMaxClassLen, LPDWORD lpcValues, LPDWORD lpcbMaxValueNameLen, LPDWORD lpcbMaxValueLen, LPDWORD lpcbSecurityDescriptor, PFILETIME lpftLastWriteTime);
-DECLSPEC_IMPORT WINAPI BOOL KERNEL32$FileTimeToSystemTime(const FILETIME *lpFileTime, LPSYSTEMTIME   lpSystemTime);
-DECLSPEC_IMPORT WINAPI int SHLWAPI$SHFormatDateTimeA(const FILETIME *pft, DWORD *pdwFlags, LPSTR *pszBuf, UINT cchBuf);
 WINBASEAPI void* WINAPI MSVCRT$malloc(SIZE_T);
 
 typedef struct _regkeyval{

--- a/src/common/bofdefs.h
+++ b/src/common/bofdefs.h
@@ -209,6 +209,7 @@ WINBASEAPI BOOLEAN WINAPI SECUR32$GetUserNameExA (int NameFormat, LPSTR lpNameBu
 
 //shlwapi
 WINBASEAPI LPSTR WINAPI SHLWAPI$StrStrIA(LPCSTR lpFirst,LPCSTR lpSrch);
+WINBASEAPI int WINAPI SHLWAPI$SHFormatDateTimeA(const FILETIME *pft, DWORD *pdwFlags, LPSTR *pszBuf, UINT cchBuf);
 
 //advapi32
 WINADVAPI WINBOOL WINAPI ADVAPI32$OpenProcessToken (HANDLE ProcessHandle, DWORD DesiredAccess, PHANDLE TokenHandle);
@@ -265,6 +266,7 @@ WINADVAPI WINBOOL WINAPI ADVAPI32$ConvertSecurityDescriptorToStringSecurityDescr
 WINADVAPI WINBOOL WINAPI ADVAPI32$StartServiceA(SC_HANDLE hService,DWORD dwNumServiceArgs,LPCSTR *lpServiceArgVectors);
 WINADVAPI WINBOOL WINAPI ADVAPI32$ControlService(SC_HANDLE hService,DWORD dwControl,LPSERVICE_STATUS lpServiceStatus);
 WINADVAPI WINBOOL WINAPI ADVAPI32$EnumDependentServicesA(SC_HANDLE hService,DWORD dwServiceState,LPENUM_SERVICE_STATUSA lpServices,DWORD cbBufSize,LPDWORD pcbBytesNeeded,LPDWORD lpServicesReturned);
+WINADVAPI LSTATUS WINAPI ADVAPI32$RegQueryInfoKeyA(HKEY hKey, LPSTR lpClass, LPDWORD lpcchClass, LPDWORD lpReserved, LPDWORD lpcSubKeys, LPDWORD lpcbMaxSubKeyLen, LPDWORD lpcbMaxClassLen, LPDWORD lpcValues, LPDWORD lpcbMaxValueNameLen, LPDWORD lpcbMaxValueLen, LPDWORD lpcbSecurityDescriptor, PFILETIME lpftLastWriteTime);
 
 //NTDLL
 WINBASEAPI NTSTATUS NTAPI NTDLL$NtCreateFile(PHANDLE FileHandle,ACCESS_MASK DesiredAccess,POBJECT_ATTRIBUTES ObjectAttributes,PIO_STATUS_BLOCK IoStatusBlock,PLARGE_INTEGER AllocationSize,ULONG FileAttributes,ULONG ShareAccess,ULONG CreateDisposition,ULONG CreateOptions,PVOID EaBuffer,ULONG EaLength);
@@ -628,6 +630,7 @@ DECLSPEC_IMPORT WINBOOL WINAPI VERSION$VerQueryValueA(LPCVOID pBlock, LPCSTR lpS
 #define USER32$EnumChildWindows EnumChildWindows
 #define SECUR32$GetUserNameExA  GetUserNameExA 
 #define SHLWAPI$StrStrIA StrStrIA
+#define SHLWAPI$SHFormatDateTimeA SHFormatDateTimeA
 #define ADVAPI32$OpenProcessToken  OpenProcessToken 
 #define ADVAPI32$GetTokenInformation  GetTokenInformation 
 #define ADVAPI32$ConvertSidToStringSidA ConvertSidToStringSidA
@@ -682,6 +685,7 @@ DECLSPEC_IMPORT WINBOOL WINAPI VERSION$VerQueryValueA(LPCVOID pBlock, LPCSTR lpS
 #define ADVAPI32$StartServiceA StartServiceA
 #define ADVAPI32$ControlService ControlService
 #define ADVAPI32$EnumDependentServicesA EnumDependentServicesA
+#define ADVAPI32$RegQueryInfoKeyA RegQueryInfoKeyA
 #define NTDLL$NtCreateFile NtCreateFile
 #define NTDLL$NtClose NtClose
 #define IMAGEHLP$ImageEnumerateCertificates ImageEnumerateCertificates


### PR DESCRIPTION
1. Corrects output error in Reg_EnumKey.  The hive had no separation from the path (i.e., the \ was missing)
2. Adds call to RegQueryInfoKeyA, which allows the querying of the MACE attributes of the key/value.
3. Adds call to SHFormatDateTimeA to convert the FILETIME to a short time/date string
4. Inserts the MAC time to the output. This necessitated moving the original output of the Key/Type so that the time could be first.

Sample output:
```
HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run
	3/27/2024 11:54 AM       OPENVPN-GUI            REG_SZ          C:\Program Files\OpenVPN\bin\openvpn-gui.exe
	3/27/2024 11:54 AM       MicrosoftEdgeAutoLaunch_C46CFC0629905CC775E70B50EA8A519C   REG_SZ          "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" --no-startup-window --win-session-start
```