### PR TITLE
Fixing 'The handle is invalid' error in rg_query and reg_query_recursive

### DIFF
--- a/src/SA/reg_query/entry.c
+++ b/src/SA/reg_query/entry.c
@@ -362,9 +362,6 @@ DWORD Reg_EnumKey(const char * hostname, HKEY hivekey, DWORD Arch, const char* k
     } // end While
 
 	END:
-	if(rootkey){
-    	ADVAPI32$RegCloseKey(rootkey);
-	}
     if(currentkeyname != NULL)
         intFree(currentkeyname);
     if(currentvaluename != NULL)


### PR DESCRIPTION
This is a fix for issue ['The handle is invalid' error occurs when running req_query and reg_query_recursive.](https://github.com/trustedsec/CS-Situational-Awareness-BOF/issues/134)