### PR TITLE
Typo fix

### DIFF
--- a/src/SA/ldapsearch/entry.c
+++ b/src/SA/ldapsearch/entry.c
@@ -511,7 +511,7 @@ void ldapSearch(char * ldap_filter, char * ldap_attributes,	ULONG results_count,
     }while(stat == LDAP_SUCCESS);
 
     end: 
-    internal_printf("\nretreived %lu results total\n", totalResults);
+    internal_printf("\nretrieved %lu results total\n", totalResults);
     if(pPageHandle)
     {
         searchDone(pLdapConnection, pPageHandle);


### PR DESCRIPTION
Applied due to the potential for screenshots of ldapsearch output appearing in reports.