### PR TITLE
netshares: also display share remark/description

### DIFF
--- a/src/SA/netshares/entry.c
+++ b/src/SA/netshares/entry.c
@@ -37,22 +37,22 @@ void listSharesAdmin( wchar_t *servername)
 
 void listSharesUser( wchar_t *servername)
 {
-	PSHARE_INFO_0 output = NULL, current = NULL;
+	PSHARE_INFO_1 output = NULL, current = NULL;
 	DWORD entries = 0, pos = 0, totalentrieshint = 0; 
 	DWORD resume = 0;
 	NET_API_STATUS stat = 0;
 	//System allocated data automatically, we free it later with NetApiBufferFree Must free even on fail
-   internal_printf("Share: \n");
+   internal_printf("Share:              Remark:\n");
    internal_printf("---------------------%S----------------------------------\n", servername == NULL ? L"(Local)" : servername);
 
 	do{
-		stat = NETAPI32$NetShareEnum(servername, 0, (LPBYTE *) &output, MAX_PREFERRED_LENGTH, &entries, &totalentrieshint, &resume);
+		stat = NETAPI32$NetShareEnum(servername, 1, (LPBYTE *) &output, MAX_PREFERRED_LENGTH, &entries, &totalentrieshint, &resume);
 		if(stat == ERROR_SUCCESS || stat == ERROR_MORE_DATA)
 		{
 			current = output;
 			for(pos = 0; pos < entries; pos++)
 			{
-				internal_printf("%S\n",current->shi0_netname);
+				internal_printf("%-20S%S\n", current->shi1_netname, current->shi1_remark);
 				current++;
 			}
 		}


### PR DESCRIPTION
This pull request extends the `nethsares` functionality to also query the share's remark/description.

This information is available as low privileged user and is helpful to give further context, e.g. when enumerating SCCM roles via SMB aka [RECON-2](https://github.com/subat0mik/Misconfiguration-Manager/blob/main/attack-techniques/RECON/RECON-2/recon-2_description.md).

This does currently not query the available permission of the underlying share and should therefore presumably have no further OPSEC considerations (though I didn't investigate further).

Output before:
```
beacon> netshares sccm-sitesrv

Share: 
---------------------sccm-sitesrv----------------------------------
ADMIN$
C$
IPC$
SCCMContentLib$
SMS_123
SMS_CPSC$
SMS_DP$
SMS_SITE
SMS_SUIAgent
```

Output after:
```
beacon> netshares sccm-sitesrv

Share:              Remark:
---------------------sccm-sitesrv----------------------------------
ADMIN$              Remote Admin
C$                  Default share
IPC$                Remote IPC
SCCMContentLib$     'Configuration Manager' Content Library for site 123 (8/28/2025)
SMS_123             SMS Site 123 08/28/25
SMS_CPSC$           SMS Compressed Package Storage
SMS_DP$             ConfigMgr Site Server DP share
SMS_SITE            SMS Site 123 08/28/25
SMS_SUIAgent        SMS Software Update Installation Agent -- 08/28/25
```