### PR TITLE
ldapsearch: use DC hostname instead of IP address for LDAP connection

### DIFF
--- a/src/SA/ldapsearch/entry.c
+++ b/src/SA/ldapsearch/entry.c
@@ -400,7 +400,7 @@ void ldapSearch(char * ldap_filter, char * ldap_attributes,	ULONG results_count,
     // Taken from https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ldap/searching-a-directory
 	//////////////////////////////
     char * targetdc = (hostname == NULL) ? pdcInfo->DomainControllerAddress + 2 : hostname;
-    BeaconPrintf(CALLBACK_OUTPUT, "Binding to %s", targetdc);
+    internal_printf("[*] Binding to %s\n", targetdc);
     pLdapConnection = InitialiseLDAPConnection(targetdc, distinguishedName, ldaps);
 
     if(!pLdapConnection)

--- a/src/SA/ldapsearch/entry.c
+++ b/src/SA/ldapsearch/entry.c
@@ -399,7 +399,7 @@ void ldapSearch(char * ldap_filter, char * ldap_attributes,	ULONG results_count,
 	// Initialise LDAP Session
     // Taken from https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ldap/searching-a-directory
 	//////////////////////////////
-    char * targetdc = (hostname == NULL) ? pdcInfo->DomainControllerAddress + 2 : hostname;
+    char * targetdc = (hostname == NULL) ? pdcInfo->DomainControllerName + 2: hostname;
     internal_printf("[*] Binding to %s\n", targetdc);
     pLdapConnection = InitialiseLDAPConnection(targetdc, distinguishedName, ldaps);
 


### PR DESCRIPTION
Previously, if no hostname was explicitly specified, a domain controller was automatically discovered and the LDAP connection was established based on the resolved IP address.
    
This prevents the use of Kerberos for authentication which is problematic in hardened environments or when using members of the Protected Users group for whom NTLM is disabled.

Before:
```
beacon> ldapsearch "(samaccountname=protecteduser)" memberOf
Binding to 10.7.10.11[*] Distinguished name: DC=ludus,DC=domain
[*] targeting DC: \\EDR-DC01-2022.ludus.domain
[*] Filter: (samaccountname=protecteduser)
[*] Scope of search value: 3
[*] Returning specific attribute(s): memberOf

--------------------
memberOf: CN=Protected Users,CN=Users,DC=ludus,DC=domain, CN=Remote Desktop Users,CN=Builtin,DC=ludus,DC=domain
retreived 1 results total

beacon> make_token ludus.domain\protecteduser password
CreateToken succeeded

beacon> ldapsearch "(samaccountname=protecteduser)" memberOf
Binding to 10.7.10.11Bind Failed: 49[*] Distinguished name: DC=ludus,DC=domain
[*] targeting DC: \\EDR-DC01-2022.ludus.domain

retreived 0 results total
```

After:
```
beacon> ldapsearch "(samaccountname=protecteduser)" memberOf
[*] Distinguished name: DC=ludus,DC=domain
[*] targeting DC: \\EDR-DC01-2022.ludus.domain
[*] Binding to EDR-DC01-2022.ludus.domain
[*] Filter: (samaccountname=protecteduser)
[*] Scope of search value: 3
[*] Returning specific attribute(s): memberOf

--------------------
memberOf: CN=Protected Users,CN=Users,DC=ludus,DC=domain, CN=Remote Desktop Users,CN=Builtin,DC=ludus,DC=domain
retrieved 1 results total
```

The old behavior using NTLM authentication can still be forced by explicitly providing an IP address i.e. something like:
```
beacon> ldapsearch --dc 10.7.10.11 "(samaccountname=protecteduser)" memberOf
Bind Failed: 49[*] Distinguished name: DC=ludus,DC=domain
[*] Binding to 10.7.10.11

retrieved 0 results total

beacon> rev2self
ok

beacon> ldapsearch --dc 10.7.10.11 "(samaccountname=protecteduser)" memberOf
[*] Distinguished name: DC=ludus,DC=domain
[*] Binding to 10.7.10.11
[*] Filter: (samaccountname=protecteduser)
[*] Scope of search value: 3
[*] Returning specific attribute(s): memberOf

--------------------
memberOf: CN=Protected Users,CN=Users,DC=ludus,DC=domain, CN=Remote Desktop Users,CN=Builtin,DC=ludus,DC=domain
retrieved 1 results total
```