### PR TITLE
Added LDAP signing and sealing

### DIFF
--- a/src/SA/ldapsearch/entry.c
+++ b/src/SA/ldapsearch/entry.c
@@ -143,41 +143,54 @@ int Base64encode(char* encoded, const char* string, int len) {
 
 LDAP* InitialiseLDAPConnection(PCHAR hostName, PCHAR distinguishedName, BOOL ldaps){
 	LDAP* pLdapConnection = NULL;
-
     ULONG result;
     int portNumber = ldaps == TRUE ? 636 : 389;
 
     pLdapConnection = WLDAP32$ldap_init(hostName, portNumber);
 
-    if(ldaps == TRUE){
-
-        ULONG version = LDAP_VERSION3;
-        result = WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_VERSION, (void*)&version);
-    
-        WLDAP32$ldap_get_optionW(pLdapConnection, LDAP_OPT_SSL, &result);  //LDAP_OPT_SSL
-        if (result == 0){
-            WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_SSL, LDAP_OPT_ON);
-        }
-
-        WLDAP32$ldap_get_optionW(pLdapConnection, LDAP_OPT_SIGN, &result);  //LDAP_OPT_SIGN
-        if (result == 0){
-            WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_SIGN, LDAP_OPT_ON);
-        }
-
-        WLDAP32$ldap_get_optionW(pLdapConnection, LDAP_OPT_ENCRYPT, &result);  //LDAP_OPT_ENCRYPT
-        if (result == 0){
-            WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_ENCRYPT, LDAP_OPT_ON);
-        }
-
-        WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_SERVER_CERTIFICATE, (void*)&ServerCertCallback ); //LDAP_OPT_SERVER_CERTIFICATE
-	}
-    
     if (pLdapConnection == NULL)
     {
-      	BeaconPrintf(CALLBACK_ERROR,"Failed to establish LDAP connection on %d.", portNumber);
+      	BeaconPrintf(CALLBACK_ERROR,"[-] Failed to establish LDAP connection on %d.\n", portNumber);
         return NULL;
     }
-    //WLDAP32$ldap_set_optionA(pLdapConnection, LDAP_OPT_VERSION,&Version );
+
+    // Set LDAP version to 3 (required for many security features)
+    ULONG version = LDAP_VERSION3;
+    result = WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_VERSION, (void*)&version);
+    if (result != LDAP_SUCCESS) {
+        BeaconPrintf(CALLBACK_ERROR, "[-] Failed to set LDAP version: %lu\n", result);
+    }
+
+    if(ldaps == TRUE){
+        // For LDAPS (port 636), we need SSL
+        result = WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_SSL, LDAP_OPT_ON);
+        if (result != LDAP_SUCCESS) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to enable SSL: %lu\n", result);
+        }
+
+        // Set the certificate callback for SSL/TLS
+        result = WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_SERVER_CERTIFICATE, (void*)&ServerCertCallback);
+        if (result != LDAP_SUCCESS) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Failed to set certificate callback: %lu\n", result);
+        }
+    }
+    else {
+        // For regular LDAP (port 389), enable signing and sealing if using LDAP_AUTH_NEGOTIATE
+        // These options need to be set BEFORE binding when using Negotiate auth
+
+        // Enable LDAP signing (integrity)
+        void* value = LDAP_OPT_ON;
+        result = WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_SIGN, &value);
+        if (result != LDAP_SUCCESS) {
+            internal_printf("[!] Warning: Failed to enable LDAP signing: %lu\n", result);
+        }
+
+        // Enable LDAP sealing (encryption) - this provides confidentiality
+        result = WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_ENCRYPT, &value);
+        if (result != LDAP_SUCCESS) {
+            internal_printf("[!] Warning: Failed to enable LDAP sealing: %lu\n", result);
+        }
+    }
 
 	//////////////////////////////
 	// Bind to DC
@@ -188,14 +201,27 @@ LDAP* InitialiseLDAPConnection(PCHAR hostName, PCHAR distinguishedName, BOOL lda
                 pLdapConnection,      // Session Handle
                 distinguishedName,    // Domain DN
                 NULL,                 // Credential structure
-                LDAP_AUTH_NEGOTIATE); // Auth mode
+                LDAP_AUTH_NEGOTIATE); // Auth mode - uses current user credentials with Kerberos/NTLM
 
     if(lRtn != LDAP_SUCCESS)
     {
-    	BeaconPrintf(CALLBACK_ERROR, "Bind Failed: %lu", lRtn);
+        // Provide more detailed error information
+        if (lRtn == LDAP_STRONG_AUTH_REQUIRED) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Bind Failed: Strong authentication required (LDAP signing may be enforced by server)\n");
+        } else if (lRtn == LDAP_INVALID_CREDENTIALS) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Bind Failed: Invalid credentials\n");
+        } else if (lRtn == LDAP_UNWILLING_TO_PERFORM) {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Bind Failed: Server unwilling to perform operation (check security requirements)\n");
+        } else {
+            BeaconPrintf(CALLBACK_ERROR, "[-] Bind Failed with error: %lu\n", lRtn);
+        }
         WLDAP32$ldap_unbind(pLdapConnection);
-        pLdapConnection = NULL; 
+        pLdapConnection = NULL;
     }
+    else {
+        internal_printf("[+] Successfully bound to LDAP server\n");
+    }
+
     return pLdapConnection;
 }
 
@@ -399,8 +425,8 @@ void ldapSearch(char * ldap_filter, char * ldap_attributes,	ULONG results_count,
 	// Initialise LDAP Session
     // Taken from https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ldap/searching-a-directory
 	//////////////////////////////
-    char * targetdc = (hostname == NULL) ? pdcInfo->DomainControllerAddress + 2 : hostname;
-    BeaconPrintf(CALLBACK_OUTPUT, "Binding to %s", targetdc);
+    char * targetdc = (hostname == NULL) ? pdcInfo->DomainControllerName + 2: hostname;
+    internal_printf("[*] Binding to %s\n", targetdc);
     pLdapConnection = InitialiseLDAPConnection(targetdc, distinguishedName, ldaps);
 
     if(!pLdapConnection)


### PR DESCRIPTION
## Fix LDAP signing and sealing implementation

### Summary
The current code attempts to enable LDAP signing but has several issues. While it currently works (likely due to Windows automatically negotiating signing when required), this PR fixes the implementation for correctness and clarity. This PR makes the behavior explicit and guaranteed.

**Current code:** https://github.com/trustedsec/CS-Situational-Awareness-BOF/blob/master/src/SA/ldapsearch/entry.c#L152-L165

### Issues I found

#### 1. Wrong protocol for signing and sealing
The current code enables signing and sealing for **LDAPS only** (port 636), which doesn't make sense since LDAPS already has encryption via TLS. In fact, Active Directory doesn't even support enforcing signing requirements for LDAPS connections, so configuring them for LDAPS is redundant.

#### 2. Missing for regular LDAP
Signing/sealing options are not applied to regular **LDAP** (port 389) connections, which is where they're actually needed. The original code still works in practice because `LDAP_AUTH_NEGOTIATE` combined with common client-side settings (e.g., "Network security: LDAP client signing requirements") can cause Windows to automatically enable signing. I verified this with Wireshark on Windows 10 domain-joined device. I did however encounter a situation on a test where this negotiation failed, but unfortunately I didn't have time to dig into it then.

#### 3. Incorrect logic
The code misuses `ldap_get_optionW`:

```c
WLDAP32$ldap_get_optionW(pLdapConnection, LDAP_OPT_SIGN, &result);
if (result == 0){
    WLDAP32$ldap_set_optionW(pLdapConnection, LDAP_OPT_SIGN, LDAP_OPT_ON);
}
```

[ldap_get_optionW](https://learn.microsoft.com/en-us/windows/win32/api/winldap/nf-winldap-ldap_get_optionw) returns a **status code** (0 = success), not the option's current value. The check `if (result == 0)` tests whether the get operation succeeded, not whether signing is enabled.

### Proposed changes

- **Move signing and sealing to LDAP-only:** Apply `LDAP_OPT_SIGN` and `LDAP_OPT_ENCRYPT` only for regular LDAP (port 389)
- **Remove signing and sealing from LDAPS:** LDAPS connections are now only configured for SSL/TLS, not signing and sealing.
- **Direct option setting:** Set LDAP options directly without unnecessary checks
- **Enhanced error handling:** Added detailed bind failure messages for common authentication errors.
- **Minor fixes I added because I was so deep into this:**
  - Changed `DomainControllerAddress` to `DomainControllerName`
  - Fixed output formatting consistency

<img width="349" height="65" alt="image" src="https://github.com/user-attachments/assets/43cd6426-5149-46bc-b832-66a54971949b" />
