### PR TITLE
Fix for : "Could not initialize com"

### DIFF
--- a/src/SA/schtasksenum/entry.c
+++ b/src/SA/schtasksenum/entry.c
@@ -14,7 +14,7 @@
 void enumTasks(const wchar_t * server)
 {
 	//Set up com
-	HRESULT hr = OLE32$CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+	HRESULT hr = OLE32$CoInitializeEx(NULL, COINIT_MULTITHREADED);
 	if(FAILED(hr))
 	{
 		BeaconPrintf(CALLBACK_ERROR, "Could not initialize com");


### PR DESCRIPTION
Switching to COINIT_MULTITHREADED aligns with Beacon’s thread environment, and now Task Scheduler COM can initialize properly.