### PR TITLE
whoami: Fix various error handling and cleanup issues

### DIFF
--- a/src/SA/whoami/entry.c
+++ b/src/SA/whoami/entry.c
@@ -115,9 +115,12 @@ int WhoamiUser(void)
     internal_printf("\nUserName\t\tSID\n");
     internal_printf("====================== ====================================\n");
 
-    ADVAPI32$ConvertSidToStringSidA(pUserInfo->User.Sid, &pSidStr);
+    if(ADVAPI32$ConvertSidToStringSidA(pUserInfo->User.Sid, &pSidStr)) {
+        internal_printf("%s\t%s\n\n", pUserStr, pSidStr);
+        KERNEL32$LocalFree(pSidStr);
+        pSidStr = NULL;
+    };
 
-    internal_printf("%s\t%s\n\n", pUserStr, pSidStr);
 
 
     /* cleanup our allocations */

--- a/src/SA/whoami/entry.c
+++ b/src/SA/whoami/entry.c
@@ -71,7 +71,7 @@ VOID* WhoamiGetTokenInfo(TOKEN_INFORMATION_CLASS TokenType)
                                  dwLength,
                                  &dwLength))
         {
-            internal_printf("ERROR 0x%x: could not get token information.\r\n", GetLastError());
+            internal_printf("ERROR 0x%x: could not get token information.\r\n", KERNEL32$GetLastError());
             goto cleanup;
         }
         pResult = pTokenInfo;


### PR DESCRIPTION
Disclosure: I used AI to identify and help me fix this bug. I understand what the code does and have confirmed the fixes are correct and compiles.

c82f89ad0500add1efcddb87f604fbddd06a80d4 The original code had a fall-through bug where if `GetLastError()` returned anything other than `ERROR_INSUFFICIENT_BUFFER`, the function would skip the buffer allocation but still call `GetTokenInformation` with a NULL buffer. It also had `CloseHandle`/`intFree` calls duplicated across multiple return paths. Changes in this commit:
  - Single cleanup label at the end of the function instead of duplicated cleanup in each error path
  - Separate pResult variable so cleanup doesn't free the buffer on success
  - Go to cleanup if the first call fails with an unexpected error
  - Uncommented error messages and switched to internal_printf

ecf90e546c90e0936071b79b11bd908d88043b95 Checked the return value of `ConvertSidToStringSidA` in `WhoamiUser` and free, matching the pattern used in the `WhoamiGroups` function.
