### PR TITLE
sha256 fails to read output and kills implants.

### DIFF
--- a/src/SA/sha256/entry.c
+++ b/src/SA/sha256/entry.c
@@ -49,8 +49,8 @@ BOOL SHAFile(LPCSTR lpszFile) {
         }
         BeaconPrintf(CALLBACK_OUTPUT, "SHA-256 Hash for %s: %s", lpszFile, hash);
     }
-    ADVAPI32$CryptReleaseContext(hProv, 0);
     ADVAPI32$CryptDestroyHash(hHash);
+    ADVAPI32$CryptReleaseContext(hProv, 0);
     KERNEL32$CloseHandle(hFile);
     return(TRUE);
 }


### PR DESCRIPTION
After making this change the bof functions as intended

Resources should be released in reverse order of acquisition:
1. Destroy hash objects first
2. Release CSP context
3. Close any file/object handles